### PR TITLE
Remove check for MOC instance variable in `saveContextAndWait:..`

### DIFF
--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -60,7 +60,8 @@ NSString *const MDMPersistenceControllerDidInitialize = @"MDMPersistenceControll
 }
 
 - (instancetype)init {
-    ZAssert(nil, @"ERROR: Ensure MDMPersistenceController is instantiated using the designated initializer(s)");
+    ALog(@"ERROR: Ensure MDMPersistenceController is instantiated using the designated initializer(s)");
+    
     return nil;
 }
 


### PR DESCRIPTION
@mmorey 
This is very much up for discussion.

There seems to be an unnecessary check on `self.managedObjectContext` inside `saveContextAndWait:` .. as you previously mentioned this should never be `nil`

In an attempt to safeguard against it possibly being `nil` ... I've overridden `-(instanceType)init` to return nil in the event of `init` being accidentally called (instead of using one of the designated initializers)
