### PR TITLE
Ensuring `completion` exists before trying to call it

### DIFF
--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -195,7 +195,9 @@ NSString *const MDMPersistenceControllerDidInitialize = @"MDMPersistenceControll
         }]; // Managed Object Context block
     } else {
         // No changes to either managedObjectContext or writerObjectContext
-        completion(nil);
+        if (completion) {
+            completion(nil);
+        }
     }
 }
 


### PR DESCRIPTION
@mmorey 
Sorry, I missed this check in my latest contribution .. better late than never :wink: 
