### PR TITLE
Call completion block if writerObjectContext doesn't have changes to save

### DIFF
--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -191,6 +191,12 @@ NSString *const MDMPersistenceControllerDidInitialize = @"MDMPersistenceControll
                 } else {
                     [self.writerObjectContext performBlock:[self savePrivateWriterContextBlockWithCompletion:completion]];
                 }
+                
+                return;
+            }
+            
+            if (completion) {
+                completion(nil);
             }
         }]; // Managed Object Context block
     } else {


### PR DESCRIPTION
Hi,

In the `- (void)saveContextAndWait:(BOOL)wait completion:(void (^)(NSError *error))completion` method of `MDMPersistenceController` it's possible for the `managedObjectContext` property to have changes while the `writerObjectContext` property does not; in that case the completion block is never called. This PR ensures the completion block is called in that scenario.

Cheers!
