### PR TITLE
Added UIKit import to the table and collection data source classes

### DIFF
--- a/Classes/MDMFetchedResultsCollectionDataSource/MDMFetchedResultsCollectionDataSource.h
+++ b/Classes/MDMFetchedResultsCollectionDataSource/MDMFetchedResultsCollectionDataSource.h
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#import <UIKit/UIKit.h>
 
 @class MDMFetchedResultsCollectionDataSource;
 

--- a/Classes/MDMFetchedResultsTableDataSource/MDMFetchedResultsTableDataSource.h
+++ b/Classes/MDMFetchedResultsTableDataSource/MDMFetchedResultsTableDataSource.h
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#import <UIKit/UIKit.h>
 
 @class MDMFetchedResultsTableDataSource;
 


### PR DESCRIPTION
Brand new projects in iOS 8 do not come with a pre compiled header. Adding these imports will allow a new iOS 8 project to compile without having to create a pre compiled header.