### PR TITLE
Added feature - creating a new independent managed object context

### DIFF
--- a/Classes/MDMPersistenceController/MDMPersistenceController.h
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.h
@@ -76,6 +76,18 @@ extern NSString *const MDMPersistenceControllerDidInitialize;
 - (NSManagedObjectContext *)newChildManagedObjectContext;
 
 /**
+ Returns a new independent managed object context with a concurrency type of `NSPrivateQueueConcurrencyType` using the
+ same managed object model and persistent store as the main context but a NEW persistent store coordinator. This is
+ useful when performing large (time consuming) updates to the database in the background. The main context
+ can continue to read from the store but will have to wait to perform any updates - this uses the WAL
+ feature of SQLite (default SQLite mode from iOS7 onwards).
+ 
+ @return A private independent managed object context with a concurrency type of `NSPrivateQueueConcurrencyType`
+ or nil if an error occured.
+ */
+- (NSManagedObjectContext *)createPrivateManagedObjectContextWithNewPersistentStoreCoordinator;
+
+/**
  Attempts to commit unsaved changes to registered objects to disk.
  
  @param wait If set the primary context is saved synchronously otherwise asynchronously.

--- a/Classes/MDMPersistenceController/MDMPersistenceController.h
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.h
@@ -30,6 +30,11 @@
 extern NSString *const MDMPersistenceControllerDidInitialize;
 
 /**
+ Posted whenever any independent managed object context (created thru this class) completes a save operation.
+ */
+extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
+
+/**
  `MDMPersistenceController` is a lightweight class that sets up an efficient Core Data stack with support for
  creating multiple child managed object contexts. A private managed object context is used for asynchronous
  saving. A SQLite store is used for data persistence.

--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -25,6 +25,7 @@
 #import "MDMCoreDataMacros.h"
 
 NSString *const MDMPersistenceControllerDidInitialize = @"MDMPersistenceControllerDidInitialize";
+NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndpendentManagedObjectContextDidSaveNotification";
 
 @interface MDMPersistenceController ()
 
@@ -299,7 +300,25 @@ NSString *const MDMPersistenceControllerDidInitialize = @"MDMPersistenceControll
         return nil;
     }
     
+    // Setup observer to receive this context's save operation completion and further broadcast using predefined notification name.
+    if(privateContext) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(independentManagedObjectContextDidSaveNotification:)
+                                                     name:NSManagedObjectContextDidSaveNotification
+                                                   object:(privateContext)];
+    }
+
     return privateContext;
+}
+
+/**
+ Receive notification whenever any independent context (created thru this class) completes save operation and further
+ broadcast using a predefined notification name.
+ */
+- (void)independentManagedObjectContextDidSaveNotification:(NSNotification *)notification {
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:MDMIndpendentManagedObjectContextDidSaveNotification
+                                                        object:notification.object];
 }
 
 #pragma mark - NSNotificationCenter

--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -301,12 +301,10 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
     }
     
     // Setup observer to receive this context's save operation completion and further broadcast using predefined notification name.
-    if(privateContext) {
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(independentManagedObjectContextDidSaveNotification:)
-                                                     name:NSManagedObjectContextDidSaveNotification
-                                                   object:(privateContext)];
-    }
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(independentManagedObjectContextDidSaveNotification:)
+                                                 name:NSManagedObjectContextDidSaveNotification
+                                               object:(privateContext)];
 
     return privateContext;
 }

--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -312,13 +312,20 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
 }
 
 /**
- Receive notification whenever any independent context (created thru this class) completes save operation and further
- broadcast using a predefined notification name.
+ Called whenever any independent context (created thru this class) completes save operation and further
+ broadcasts using a predefined notification name.
  */
 - (void)independentManagedObjectContextDidSaveNotification:(NSNotification *)notification {
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:MDMIndpendentManagedObjectContextDidSaveNotification
+
+    if([NSThread isMainThread] == NO) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:MDMIndpendentManagedObjectContextDidSaveNotification
+                                                                object:notification.object];
+        });
+    } else {
+        [[NSNotificationCenter defaultCenter] postNotificationName:MDMIndpendentManagedObjectContextDidSaveNotification
                                                         object:notification.object];
+    }
 }
 
 #pragma mark - NSNotificationCenter

--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -304,7 +304,7 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(independentManagedObjectContextDidSaveNotification:)
                                                  name:NSManagedObjectContextDidSaveNotification
-                                               object:(privateContext)];
+                                               object:privateContext];
 
     return privateContext;
 }

--- a/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
+++ b/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
@@ -263,7 +263,9 @@ NSString * const kTestEntityName = @"Test";
     [self createTestEntitiesAndWaitWithContext:backgroundMOC objectCount:objCountBG];
     
     //Start concurrent operations - one for background save and another for foreground fetch
-    //  Time taken for foreground retrieve should not exceed 1 second
+    //  Time taken for foreground retrieve should not exceed 1 second (observed around 0.0002 seconds
+    //  for fetch vs 12 seconds for saving 1 million Test entities on a Mac Book Pro 2.8GHz Intel Core
+    //  i7 based iPhone Simulator debug mode)
     //  It is feasible to calibrate for the expected fetch time on current running device - but a max of 1 second should suffice for this test.
     
     //Concurrent Op 1: Background Save

--- a/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
+++ b/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
@@ -50,7 +50,6 @@ NSString * const kTestEntityName = @"Test";
     NSManagedObjectModel *mom = [[NSManagedObjectModel alloc] init];
     NSEntityDescription *testEntity = [[NSEntityDescription alloc] init];
     [testEntity setName:kTestEntityName];
-    //[testEntity setManagedObjectClassName:@"Test"]; This class is not defined so lets define it or remove this line to avoid runtime warning.
     NSAttributeDescription *stringAttribute = [[NSAttributeDescription alloc] init];
     [stringAttribute setName:@"testString"];
     [stringAttribute setAttributeType:NSStringAttributeType];

--- a/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
+++ b/Example/MDMCoreDataTests/MDMPersistenceControllerTests.m
@@ -291,14 +291,13 @@ NSString * const kTestEntityName = @"Test";
     }];
     
     //Concurrent Op 2: Foreground Fetch
-    sleep(0.05); //let the background save begin
     NSTimeInterval maxExpectedFetchTime = 1.0;
     NSDate * multifetchStartTime = [NSDate date];
     NSLog(@"Foreground Multiple Fetch start time %@", multifetchStartTime);
-    // Looping serves two purposes:
-    // 1) Accounts for cases where background save does not start immediately - though the sleep above should most likely suffice.
-    // 2) Demonstrating the difference in fetch times (before and after save completion) when using non-independent backgroundMOC.
+    // Looping demonstrates the typical use case where fetches continue to happen in the
+    // foreground triggered by user interaction - while a background save is in progress.
     for (int index =0; index<3; index++) {
+        sleep(0.05); //user interaction
         [foregroundMOC reset];
         [self fetchInContext:foregroundMOC validateObjectCount:-1.0 validateMaxFetchTime:maxExpectedFetchTime];
     }


### PR DESCRIPTION
Added feature: Create a new independent managed object context with a concurrency type of `NSPrivateQueueConcurrencyType` using the
same managed object model and persistent store as the main context but a NEW persistent store coordinator. This is
useful when performing large (time consuming) updates to the database in the background. The main context
can continue to read from the store but will have to wait to perform any updates - this uses the WAL
feature of SQLite (default SQLite mode from iOS7 onwards).