### PR TITLE
NSInMemoryStoreType option

### DIFF
--- a/Classes/MDMPersistenceController/MDMPersistenceController.h
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.h
@@ -47,7 +47,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
 @property (nonatomic, strong, readonly) NSManagedObjectContext *managedObjectContext;
 
 /**
- Returns a persistence controller initialized with the given arguments.
+ Returns a SQLite backed persistence controller initialized with the given arguments.
  
  @param storeURL The URL of the SQLite store to load.
  @param model A managed object model.
@@ -57,7 +57,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
 - (id)initWithStoreURL:(NSURL *)storeURL model:(NSManagedObjectModel *)model;
 
 /**
- Returns a persistence controller initialized with the given arguments.
+ Returns a SQLite backed persistence controller initialized with the given arguments.
  
  @param storeURL The URL of the SQLite store to load.
  @param modelURL The URL of the managed object model.
@@ -65,6 +65,24 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
  @return A new persistence controller object with a store at the specified location and a model at the specified location.
  */
 - (id)initWithStoreURL:(NSURL *)storeURL modelURL:(NSURL *)modelURL;
+
+/**
+ Returns an inMemory backed persistence controller initialized with the given arguments.
+ 
+ @param model A managed object model.
+ 
+ @return A new persistence controller object with an inMemoryStore type with model.
+ */
+- (id)initInMemoryTypeWithModel:(NSManagedObjectModel *)model;
+
+/**
+ Returns an inMemory backed persistence controller initialized with the given arguments.
+ 
+ @param modelURL The URL of the managed object model.
+ 
+ @return A new persistence controller object with an inMemoryStore type with a model at the specified location.
+ */
+- (id)initInMemoryTypeWithModelURL:(NSURL *)modelURL;
 
 /**
  Returns a new private child managed object context with a concurrency type of `NSPrivateQueueConcurrencyType`.

--- a/Classes/MDMPersistenceController/MDMPersistenceController.h
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.h
@@ -54,7 +54,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
 
  @return A new persistence controller object with a store at the specified location with model.
  */
-- (id)initWithStoreURL:(NSURL *)storeURL model:(NSManagedObjectModel *)model;
+- (instancetype)initWithStoreURL:(NSURL *)storeURL model:(NSManagedObjectModel *)model;
 
 /**
  Returns a SQLite backed persistence controller initialized with the given arguments.
@@ -64,7 +64,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
 
  @return A new persistence controller object with a store at the specified location and a model at the specified location.
  */
-- (id)initWithStoreURL:(NSURL *)storeURL modelURL:(NSURL *)modelURL;
+- (instancetype)initWithStoreURL:(NSURL *)storeURL modelURL:(NSURL *)modelURL;
 
 /**
  Returns an inMemory backed persistence controller initialized with the given arguments.
@@ -73,7 +73,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
  
  @return A new persistence controller object with an inMemoryStore type with model.
  */
-- (id)initInMemoryTypeWithModel:(NSManagedObjectModel *)model;
+- (instancetype)initInMemoryTypeWithModel:(NSManagedObjectModel *)model;
 
 /**
  Returns an inMemory backed persistence controller initialized with the given arguments.
@@ -82,7 +82,7 @@ extern NSString *const MDMIndpendentManagedObjectContextDidSaveNotification;
  
  @return A new persistence controller object with an inMemoryStore type with a model at the specified location.
  */
-- (id)initInMemoryTypeWithModelURL:(NSURL *)modelURL;
+- (instancetype)initInMemoryTypeWithModelURL:(NSURL *)modelURL;
 
 /**
  Returns a new private child managed object context with a concurrency type of `NSPrivateQueueConcurrencyType`.

--- a/Classes/MDMPersistenceController/MDMPersistenceController.m
+++ b/Classes/MDMPersistenceController/MDMPersistenceController.m
@@ -39,7 +39,7 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
 
 @implementation MDMPersistenceController
 
-- (id)initWithStoreURL:(NSURL *)storeURL model:(NSManagedObjectModel *)model {
+- (instancetype)initWithStoreURL:(NSURL *)storeURL model:(NSManagedObjectModel *)model {
     
     self = [super init];
     if (self) {
@@ -54,7 +54,7 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
     return self;
 }
 
-- (id)initInMemoryTypeWithModel:(NSManagedObjectModel *)model {
+- (instancetype)initInMemoryTypeWithModel:(NSManagedObjectModel *)model {
     
     self = [super init];
     if (self) {
@@ -68,7 +68,7 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
     return self;
 }
 
-- (id)initWithStoreURL:(NSURL *)storeURL modelURL:(NSURL *)modelURL {
+- (instancetype)initWithStoreURL:(NSURL *)storeURL modelURL:(NSURL *)modelURL {
     
     NSManagedObjectModel *model = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
     ZAssert(model, @"ERROR: NSManagedObjectModel is nil");
@@ -76,7 +76,7 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
     return [self initWithStoreURL:storeURL model:model];
 }
 
-- (id)initInMemoryTypeWithModelURL:(NSURL *)modelURL {
+- (instancetype)initInMemoryTypeWithModelURL:(NSURL *)modelURL {
     
     NSManagedObjectModel *model = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
     ZAssert(model, @"ERROR: NSManagedObjectModel is nil");
@@ -132,15 +132,16 @@ NSString *const MDMIndpendentManagedObjectContextDidSaveNotification = @"MDMIndp
             
             return nil;
         }
-        
-        if (persistentStore == nil) {
-            
-            // Something really bad is happening
-            ALog(@"ERROR: NSPersistentStore is nil: %@\n%@", [persistentStoreError localizedDescription], [persistentStoreError userInfo]);
-            
-            return nil;
-        }
     }
+    
+    if (persistentStore == nil) {
+        
+        // Something really bad is happening
+        ALog(@"ERROR: NSPersistentStore is nil: %@\n%@", [persistentStoreError localizedDescription], [persistentStoreError userInfo]);
+        
+        return nil;
+    }
+    
     return persistentStoreCoordinator;
 }
 

--- a/Example/MDMCoreData/MDMAppDelegate.m
+++ b/Example/MDMCoreData/MDMAppDelegate.m
@@ -26,6 +26,8 @@
 #import <MDMCoreData.h>
 #import "MDMCoreDataFatalErrorAlertView.h"
 
+// #define USE_IN_MEMORY_STORE
+
 @interface MDMAppDelegate ()
 
 @property (nonatomic, strong) MDMPersistenceController *persistenceController;
@@ -71,9 +73,15 @@
 - (MDMPersistenceController *)persistenceController {
     
     if (_persistenceController == nil) {
-        NSURL *storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"MDMCoreData.sqlite"];
         NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"MDMCoreData" withExtension:@"momd"];
+        
+#ifdef USE_IN_MEMORY_STORE
+        _persistenceController = [[MDMPersistenceController alloc] initInMemoryTypeWithModelURL:modelURL];
+#else
+        NSURL *storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"MDMCoreData.sqlite"];
         _persistenceController = [[MDMPersistenceController alloc] initWithStoreURL:storeURL modelURL:modelURL];
+#endif
+
         if (_persistenceController == nil) {
             
             ALog(@"ERROR: Persistence controller could not be created");

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ To run the example project clone the repo and open `MDMCoreData.xcworkspace`. A 
 
 ### MDMPersistenceController
 
-To create a new `MDMPersistenceController` call `initWithStoreURL:modelURL:` with the URLs of the SQLite file and data model.
+#### Store type - SQLite (`NSSQLiteStoreType`)
+The typical store type used when utilizing Core Data is `SQLite`. To create a new `MDMPersistenceController` call `initWithStoreURL:modelURL:` with the URLs of the SQLite file and data model.
 
 ```objective-c
 NSURL *storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"MDMCoreData.sqlite"];
@@ -54,6 +55,16 @@ self.persistenceController = [[MDMPersistenceController alloc] initWithStoreURL:
                                                                        modelURL:modelURL];
 ```
 
+#### Store type - InMemory (`NSInMemoryStoreType`)
+An alternative (not a widely used) store type is an `InMemory` store. This type of store is particularly useful when long term persistence is not required e.g. testing.  
+To create a new `MDMPersistenceController` (backed by an inMemoryStore type) call ` initInMemoryTypeWithModelURL:modelURL` with the URL of the data model.
+
+```objective-c
+NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"MDMCoreData" withExtension:@"momd"];
+self.persistenceController = [[MDMPersistenceController alloc] initInMemoryTypeWithModelURL:modelURL];
+```
+
+#### Managed Object Context
 Easily access the main queue managed object context via the public `managedObjectContext` property.
 
 ```objective-c
@@ -71,6 +82,7 @@ To save changes, call `saveContextAndWait:completion:` with an optional completi
 }];
 ```
 
+#### Child contexts
 New child contexts can be created with the main queue or a private queue for background work.
 
 ```objective-c


### PR DESCRIPTION
@mmorey, @tLewisII and contributing team

During my latest project, I found I would setup and teardown a persistenceController quite a number of times to thoroughly test a Core Data backed application. Using mocks would have been ok, but I really wanted to lean on the features that CD provides.
With this in mind .. and wanting to keep my test run-time as low as possible ... I thought using an InMemoryStoreType would be more efficient than hitting the disk for an SQLite file.

#### MDMPersistenceController API
Not wanting to make any breaking changes to the existing interface, I added a 2 new initializers to the MDMPersistenceController API to allow for creating an inMemoryStoreType.
I've tried to mimic the functionality of the existing default (`SQLite`) initializers.

```objc
- (id)initInMemoryTypeWithModel:(NSManagedObjectModel *)model
```
```objc
- (id)initInMemoryTypeWithModelURL:(NSURL *)modelURL
```




*Before I pursue this, I wanted to get your thoughts .. is this feature necessary or does it complicate things ?*
